### PR TITLE
Repository wiki documentation

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,28 @@
+## Panelin Wiki (BMC Assistant Pro)
+
+Bienvenido/a a la Wiki del repositorio **Panelin**: un sistema para cotizaciones técnicas y asistencia comercial (BMC) con:
+
+- **Configuración de GPT (Builder)**: instrucciones + Knowledge Base jerarquizada (Nivel 1 → 4).
+- **Setup vía API**: creación automatizada del assistant con modelo explícito.
+- **Motor Python de cotización**: cálculo de materiales/precios con base de conocimiento.
+- **KB Update + Training**: optimizadores, cache y scheduler para mantener la KB y datos de entrenamiento.
+- **Agents SDK (TypeScript)**: orquestación multi-agente con guardrails y routing.
+
+### Empezar rápido
+
+- **Configurar el GPT en Builder**: ver `PANELIN_SETUP_COMPLETE.md` y `PANELIN_FULL_CONFIGURATION.md`.
+- **Crear Panelin vía API**: ver `SETUP_PANELIN_API.md` (script `setup_panelin_with_model.py`).
+- **KB Update System**: ver `KB_UPDATE_QUICKSTART.md` y `KB_UPDATE_COMMANDS.md`.
+- **Agents SDK**: ver `PANELIN_AGENTS_SDK_QUICKSTART.md`.
+
+### Navegación
+
+Usa la barra lateral para ir a:
+
+- **Overview** (qué es este repo, componentes y entrypoints)
+- **Setup** (Builder / API / variables de entorno)
+- **KB & Training** (optimización, tiers, scheduler)
+- **Agents SDK** (arquitectura, scripts y tools)
+- **Motor de cotización (Python)** (cómo corre, inputs/outputs)
+- **Troubleshooting** (errores típicos y soluciones)
+

--- a/wiki/Publishing-Guide.md
+++ b/wiki/Publishing-Guide.md
@@ -1,0 +1,39 @@
+## Cómo publicar esta Wiki en GitHub
+
+GitHub maneja la **Wiki** como un repositorio separado: `<repo>.wiki.git`. Este proyecto incluye las páginas en `wiki/` para que:
+
+- queden versionadas junto al código, y
+- se puedan copiar/sincronizar fácilmente a la Wiki oficial de GitHub.
+
+### Opción A (recomendada): mantenerla in-repo
+
+- Edita las páginas en `wiki/`
+- En tu README o docs internas, enlaza a `wiki/Home.md`
+
+### Opción B: publicar a la GitHub Wiki (repositorio separado)
+
+1. Cloná la wiki del repo (en tu máquina):
+
+```bash
+git clone <REPO_URL>.wiki.git
+```
+
+2. Copiá el contenido de `wiki/` dentro del repo `.wiki.git` (manteniendo los nombres):
+   - `Home.md`
+   - `_Sidebar.md`
+   - (resto de páginas)
+
+3. Commit y push:
+
+```bash
+git add .
+git commit -m "Update wiki"
+git push
+```
+
+### Convención de nombres
+
+- `Home.md` es la página principal.
+- `_Sidebar.md` define el menú lateral.
+- Los links en la wiki se escriben como `([Título](Nombre-De-Página))` sin extensión.
+

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,29 @@
+## Panelin Wiki
+
+- [Home](Home)
+- [Project Overview](Project-Overview)
+- [Architecture](Architecture)
+- [Setup (Builder)](Setup-Builder)
+- [Setup (API)](Setup-API)
+- [Environment & Secrets](Environment-and-Secrets)
+- [Knowledge Base & File Hierarchy](Knowledge-Base-and-File-Hierarchy)
+- [KB Update System](KB-Update-System)
+- [Training Data Pipeline](Training-Data-Pipeline)
+- [Python Quotation Engine](Python-Quotation-Engine)
+- [Agents SDK (TypeScript)](Agents-SDK)
+- [Operational Commands (SOP)](Operational-Commands)
+- [Troubleshooting](Troubleshooting)
+- [FAQ](FAQ)
+- [Glossary](Glossary)
+
+---
+
+## Repo docs (fuente)
+
+- `PANELIN_SETUP_COMPLETE.md`
+- `PANELIN_FULL_CONFIGURATION.md`
+- `SETUP_PANELIN_API.md`
+- `KB_UPDATE_QUICKSTART.md`
+- `KB_UPDATE_COMMANDS.md`
+- `PANELIN_AGENTS_SDK_QUICKSTART.md`
+


### PR DESCRIPTION
Add initial GitHub Wiki structure and publishing guide to start the repository documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-882a80c6-74b0-432b-b3ed-ad75638f3e79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-882a80c6-74b0-432b-b3ed-ad75638f3e79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>